### PR TITLE
Tools now require .NET 10 or .NETFx 4.72 runtimes.

### DIFF
--- a/GPLEX/AAST.cs
+++ b/GPLEX/AAST.cs
@@ -839,7 +839,9 @@ namespace QUT.Gplex.Parser {
 
         internal RegExException( int errorNum, int stringIx, int count, string message ) { errNo = errorNum; index = stringIx; length = count; text = message; }
 
+#if !NET
         protected RegExException( SerializationInfo i, StreamingContext c ) : base( i, c ) { }
+#endif
 
         internal RegExException AdjustIndex( int delta ) { this.index += delta; return this; }
 

--- a/GPLEX/Utils.cs
+++ b/GPLEX/Utils.cs
@@ -442,9 +442,10 @@ namespace QUT.Gplex.Parser
         public StringInterpretException(string text) : base(text) { }
         public StringInterpretException(string text, string key) : base(text) { this.key = key; }
         public StringInterpretException(string message, Exception inner) : base(message, inner) { }
+#if !NET
         protected StringInterpretException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
-
+#endif
     }
 
     [Serializable]
@@ -453,8 +454,10 @@ namespace QUT.Gplex.Parser
         public GplexInternalException() { }
         public GplexInternalException(string message) : base(message) { }
         public GplexInternalException(string message, Exception inner) : base(message, inner) { }
+#if !NET
         protected GplexInternalException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
+#endif
     }
 
     [Serializable]
@@ -463,7 +466,9 @@ namespace QUT.Gplex.Parser
         public TooManyErrorsException() { }
         public TooManyErrorsException(string message) : base(message) { }
         public TooManyErrorsException(string message, Exception inner) : base(message, inner) { }
+#if !NET
         protected TooManyErrorsException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
+#endif
     }
 }

--- a/GPLEXv1.csproj
+++ b/GPLEXv1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyName>Gplex</AssemblyName>
     <RootNamespace>QUT.Gplex</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/MSBuild/Gplex.nuspec
+++ b/MSBuild/Gplex.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>ASNA.Gplex.Tool</id>
-    <version>0.0.1-preview1</version>
+    <version>0.0.1-preview2</version>
     <authors>GPLEX developers</authors>
     <description>Gardens Point Scanner Generator (GPLEX) binary and enhanced MSBuild targets for SDK-style projects.</description>
     <repository type="git" url="https://github.com/asnarnd/gplex" />
@@ -29,9 +29,9 @@
 
     <!-- The tool binaries. Note that the net472 binaries are included purely for distribution, they are not used by the build targets -->
     <file src="$publishdir$\net472\**\*" target="tools/net472/" />
-    <file src="$publishdir$\net6.0\**\*" target="tools/net6.0/" />
+    <file src="$publishdir$\net10.0\**\*" target="tools/net10.0/" />
 
-    <file src="..\GPLEXcopyright.rtf" target="tools/net6.0/" />
+    <file src="..\GPLEXcopyright.rtf" target="tools/net10.0/" />
     <file src="..\GPLEXcopyright.rtf" target="tools/net472/" />
 
     <file src="..\README.md" target="docs/" />

--- a/MSBuild/build/Gplex.Tool.props
+++ b/MSBuild/build/Gplex.Tool.props
@@ -10,7 +10,7 @@
       SaveGplexOutputFromIncrementalClean
     </IncrementalCleanDependsOn>
 
-    <_GplexTool>dotnet "$(MSBuildThisFileDirectory)../../tools/net6.0/Gplex.dll"</_GplexTool>
+    <_GplexTool>dotnet "$(MSBuildThisFileDirectory)../../tools/net10.0/Gplex.dll"</_GplexTool>
   </PropertyGroup>
 
   <!-- Defaults for GplexFile items -->

--- a/MSBuild/buildCrossTargeting/Gplex.Tool.props
+++ b/MSBuild/buildCrossTargeting/Gplex.Tool.props
@@ -10,7 +10,7 @@
       SaveGplexOutputFromIncrementalClean
     </IncrementalCleanDependsOn>
 
-    <_GplexTool>dotnet "$(MSBuildThisFileDirectory)../tools/net6.0/Gplex.dll"</_GplexTool>
+    <_GplexTool>dotnet "$(MSBuildThisFileDirectory)../tools/net10.0/Gplex.dll"</_GplexTool>
   </PropertyGroup>
 
   <!-- Defaults for GplexFile items -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GPLEX is a scanner generator which produces lexical scanners written in C#.  The
 This repository now includes the full documentation for the scanner-generator.
 
 ## This Fork
-The repo is a fork of the original maintained by [@k-john-gough](https://github.com/k-john-gough/gplex). The generator produced here requires a .NET runtime compatible with .NET6 or .NETFramework 4.72. The MSBuild targets contained in the NuGet package produced by the repo support .NET SDK "multi-targeting" projects (minimum .NETStandard 2.0). Targets have been modified, with improvements in incremental compilation and use in modern IDEs.
+The repo is a fork of the original maintained by [@k-john-gough](https://github.com/k-john-gough/gplex). The generator produced here requires a .NET runtime compatible with .NET10 or .NETFramework 4.72. The MSBuild targets contained in the NuGet package produced by the repo support .NET SDK "multi-targeting" projects (minimum .NETStandard 2.0). Targets have been modified, with improvements in incremental compilation and use in modern IDEs.
 
 ## Features
 _GPLEX_ generates scanners based around finite state automata.  The generated automata have the number of states minimized by default, and have a large number of options for table compression.  The default compression scheme is chosen depending on the input alphabet cardinality, and almost always gives a reasonable result.  However a large number of options are available for the user to tune the behavior if necessary.

--- a/ShiftReduceParser/ShiftReduceParserCode.cs
+++ b/ShiftReduceParser/ShiftReduceParserCode.cs
@@ -142,7 +142,9 @@ namespace QUT.Gppg {
         // This exception cannot escape from the local context
         private class AcceptException : Exception {
             internal AcceptException() { }
+#if !NET
             protected AcceptException( SerializationInfo i, StreamingContext c ) : base( i, c ) { }
+#endif
         }
         [Serializable]
         [SuppressMessage( "Microsoft.Design", "CA1064:ExceptionsShouldBePublic" )]
@@ -150,7 +152,9 @@ namespace QUT.Gppg {
         // This exception cannot escape from the local context
         private class AbortException : Exception {
             internal AbortException() { }
+#if !NET
             protected AbortException( SerializationInfo i, StreamingContext c ) : base( i, c ) { }
+#endif
         }
         [Serializable]
         [SuppressMessage( "Microsoft.Design", "CA1064:ExceptionsShouldBePublic" )]
@@ -158,7 +162,9 @@ namespace QUT.Gppg {
         // This exception cannot escape from the local context
         private class ErrorException : Exception {
             internal ErrorException() { }
+#if !NET
             protected ErrorException( SerializationInfo i, StreamingContext c ) : base( i, c ) { }
+#endif
         }
 
         // The following methods are only called from within


### PR DESCRIPTION
Tools now require .NET 10 or .NETFx 4.72 runtimes. The tools will no
longer run on .NET 6 runtime, though code generated by the tools can
still target most any .NET SDK. Also, fix serialization deprecation
warnings.